### PR TITLE
Update/simplify the SummarizedExperiment export example of the vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RmzTabM
 Title: R API for the mzTab-M Reference Implementation
-Version: 0.97.16
+Version: 0.97.17
 Authors@R: c(
     person(given = "Nils",
            family = "Hoffmann",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,11 +48,6 @@ Imports:
     SummarizedExperiment
 Suggests:
     testthat,
-    alabaster.se,
-    xcms,
-    MsIO,
-    MsBackendMetaboLights,
-    Metabonaut,
     pkgdown,
     BiocStyle,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # RmzTabM version 0.97
 
+## Changes in version 0.97.17
+
+- Update and simplify the `SummarizedExperiment` export example in the vignette.
+
 ## Changes in version 0.97.16
 
 - Update vignette with high-level functionality to export a mzTab-M file.

--- a/R/SummarizedExperiment.R
+++ b/R/SummarizedExperiment.R
@@ -308,7 +308,7 @@ setMethod("MzTabM", signature(mtd = "SummarizedExperiment"),
               m <- mtdSkeleton(
                   id = id,
                   software = paste0(
-                      "[,,RmzTabM,RmzTabM version",
+                      "[,,RmzTabM,RmzTabM version ",
                       as.character(packageVersion("RmzTabM")), "]"))
               m <- rbind(m, mtdFromSampleData(
                   as.data.frame(colData(mtd)), sampleCols. = sampleCols.,

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ base R data types.
 - [X] core functionality to format metadata (MTD section)
 - [X] core functionality to format small molecule feature (SMF section)
 - [X] core functionality to format the (SML section)
-- [ ] core functionality to format the (SME section)
+- [X] core functionality to format the (SME section)
 - [ ] core functionality to extract metadata from an mzTab-M file and
       reconstruct a sample/experiment `data.frame`
 - [ ] core functionality to extract the SMF data table from an mzTab-M file
 - [ ] core functionality to extract the SME data table from an mzTab-M file
 - [ ] core functionality to extract the SML data table from an mzTab-M file
-- [ ] high-level functionality to simplify exporting experimental data in
-      mzTab-M format
+- [X] high-level functionality to simplify exporting experimental data in
+      mzTab-M format.
 - [ ] support for mzTab-M JSON format
 - [ ] mzTab-M file validation
 

--- a/vignettes/references.bib
+++ b/vignettes/references.bib
@@ -1,0 +1,11 @@
+@article{louail_rformassspectrometrymetabonaut_2026,
+	title = {rformassspectrometry/{Metabonaut}: v1.5.0},
+	shorttitle = {rformassspectrometry/{Metabonaut}},
+	url = {https://zenodo.org/records/19450619},
+	doi = {10.5281/zenodo.19450619},
+	urldate = {2026-06-25},
+	publisher = {Zenodo},
+	author = {Louail, Philippine and Suksi, Vilhelm and Nishida, Kozo and Graeve, Marilyn De and Rainer, Johannes},
+	month = apr,
+	year = {2026}
+}

--- a/vignettes/rmztabm-api.qmd
+++ b/vignettes/rmztabm-api.qmd
@@ -5,13 +5,14 @@ format:
   html:
     minimal: true
     theme: flatly
+bibliography: references.bib
 vignette: >
   %\VignetteIndexEntry{The R API for the mzTab-M File Format}
   %\VignetteKeywords{Mass Spectrometry, MS, MSMS, Metabolomics, Infrastructure, Quantitative}
   %\VignettePackage{RmzTabM}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{quarto::html}
-  %\VignetteDepends{RmzTabM,BiocStyle,pander}
+  %\VignetteDepends{RmzTabM,BiocStyle,pander,SummarizedExperiment}
 ---
 
 # Introduction
@@ -64,108 +65,250 @@ library(RmzTabM)
 ## High-level, user faced functions
 
 In this section we export the data set used in the *Metabonaut* end-to-end
-metabolomics data workflow in mzTab-M format. The raw MS data is available in
-MetaboLights (accession number *MTBLS8735* with 2 separate MS runs, one with
-LC-MS and a second with LC-MS/MS data for selected samples). The preprocessed
-data is available as a `SummarizedExperiment` in Metabonaut. After compiling
-all necessary experimental metadata, we export this result object as a mzTab-M
-file with only the metadata and the small feature abundances (MTD+SMF).
+metabolomics data workflow [@louail_rformassspectrometrymetabonaut_2026] in
+mzTab-M format. The raw MS data is available in MetaboLights (accession number
+*MTBLS8735* with 2 separate MS runs, one with LC-MS and a second with LC-MS/MS
+data for selected samples). The original *xcms* preprocessing result object is
+available in Metabonaut and is included also within the *RmzTabM* package. After
+collecting all necessary experimental metadata, we export this result object as
+a mzTab-M file with only the metadata and the small feature abundances
+(MTD+SMF).
+
+The *RmzTabM* package defines a `MzTabM()` convenience function to create a
+mzTab-M file from a `SummarizedExperiment` object. Information provided in such
+objects is automatically converted and formatted into content for the right
+mzTab-M section. The user simply needs to define the columns containing
+information for the various mzTab-M fields and a mzTab-M is compiled. This
+mzTab-M object should then be completed adding eventually missing data.
+
+::: {.callout-note appearance = "minimal"}
+ℹ️ individual mzTab-M sections could also be compiled individually with helper
+functions such as `mtdFromSampleData()` to generate a metadata section from a
+*sample* `data.frame`.
+:::
 
 ```{r}
 #| message: FALSE
 #' required packages
-library(alabaster.se)
-library(MsIO)
-library(xcms)
-library(Metabonaut)
-library(MsBackendMetaboLights)
+library(SummarizedExperiment)
 ```
 
 ### Get the *Metabonaut* result object
 
 Data preprocessing, normalization, statistical data analysis and annotation is
-described in [*Metabonaut* (version 1.5.0)](https://doi.org/10.5281/zenodo.15062929).
+described in [*Metabonaut* (version
+1.5.0)](https://doi.org/10.5281/zenodo.15062929)
+[@louail_rformassspectrometrymetabonaut_2026].
 
-The result object is a `SummarizedExperiment` with the preprocessing results.
+The result from the *xcms*-based preprocessing, a `SummarizedExperiment` object,
+is included within the *RmzTabM* package as the `se` data set, which we load
+below.
 
 ```{r}
-pth <- system.file("extdata", "preprocessed_res", package = "Metabonaut")
-
-se <- readObject(pth)
+#' Load the Metabonaut preprocessing result
+data(se)
 se
 ```
 
-We load also the full *xcms* result object. This is required to use the
-**correct** *m/z* and retention time ranges for the features (which are based
-on the ranges of the chromatographic peaks).
+The object contains sample information in `colData()`:
 
 ```{r}
-lcms1 <- readObject(system.file("extdata", "preprocessed_lcms1",
-                                package = "Metabonaut"))
+colData(se)
 ```
 
-Get the *feature area* and replace the *m/z* and retention time ranges in the
-`SummarizedExperiment`'s `rowData()`.
+LC-MS feature definitions and characteristics in its `rowData()`:
 
 ```{r}
-fa <- featureArea(lcms1)[rownames(se), ]
-rowData(se)$mzmin <- fa[, "mzmin"]
-rowData(se)$mzmax <- fa[, "mzmax"]
-rowData(se)$rtmin <- fa[, "rtmin"]
-rowData(se)$rtmax <- fa[, "rtmax"]
+rowData(se)
+```
+
+and has two *assays* with feature abundances, one with the original integrated
+peak areas of identified chromatographic peaks and one with additional
+gap-filled abundances.
+
+```{r}
+assayNames(se)
 ```
 
 ### Define the data set's metadata (MTD)
 
-Compiling the metadata information for the present data set. We need to
-add/adapt some columns of the `SummarizedExperiment`'s `colData()` to complete
-or match the expected format:
-
-- use a CV param for species: `"[NCBITaxon, NCBITaxon:9606, Homo sapiens, ]"`
-- blood plasma: `"[BTO, BTO:0000131, blood plasma, ]"`
-- blood serum: `"[BTO, BTO:0000133, blood serum, ]"`
-- add polarity information.
-- assign the same name to all sample pools.
-- Add the MS instrument.
+Comprehensive data set descriptions and metadata are important to enable re-use
+of the data and follow FAIR principles. Collecting the experiment's metadata
+consists mostly of manual work e.g. looking up CV parameters for used
+instruments or sample tissues. Metadata for samples and related measurements is
+ideally added to the `SummarizedExperiment`'s `colData()`. For the present data
+set sample characteristics such as the species and tissue are defined in columns
+`"species"` and `"tissue"`:
 
 ```{r}
-colData(se)$species <- "[NCBITaxon, NCBITaxon:9606, Homo sapiens, ]"
-colData(se)$tissue <- "[BTO, BTO:0000131, blood plasma, ]"
-colData(se)$tissue[colData(se)$blood_sample_type == "blood serum"] <-
-              "[BTO, BTO:0000133, blood serum, ]"
-colData(se)$polarity <- "positive"
-colData(se)$sample_name[grep("POOL", colData(se)$sample_name)] <- "POOL"
-colData(se)$instrument <- "1"
+colData(se)$species
+colData(se)$tissue
 ```
 
-We can now start compiling the metadata information from information provided
-in the `SummarizedExperiment`'s `colData()`.
+::: {.callout-note appearance = "minimal"}
+ℹ️ ideally, CV parameters should be used as much as possible to ensure a
+standardized description of the data. The [EMBL-EBI Ontology Lookup
+Service](https://www.ebi.ac.uk/ols4/) can be used to find ontology terms (CV
+parameters) for various controlled vocabularies.
+:::
+
+Also measurement-related information are defined in the `colData()`, including
+the polarity:
 
 ```{r}
-#' Key metadata information
-mtd <- mtdSkeleton(
-    id = "MTBLS8735",
-    software = "[MS, MS:1001582, xcms, 4.10.0]")
+colData(se)$polarity
+```
 
-#' define mapping of `colData()` column names to mzTab-M fields
+We can use this information to compile the data set's metadata. To this end we
+define the column names in the `SummarizedExperiment`'s `colData()` that contain
+information for sample, measurement run and assay mzTab-M fields. This mapping
+of mzTab-M fields to column names can be defined with the `sampleCols()`,
+`msRunCols()` and `assayCols()` helper functions. We use for example the content
+of the column `"sample_name"` for the mzTab-M *sample* name. Content from the
+`colData()` columns `"species"`, `"tissue"` and `"sample_type"` is used for
+mzTab-M sample fields `species`, `tissue` and `sample_type`.
+
+```{r}
+colData(se)$sample_name
+#' define mapping of `colData()` column names to mzTab-M sample fields
 scols <- sampleCols(sample = "sample_name", species = "species",
                     tissue = "tissue", sample_type = "sample_type")
+```
+
+Similarly we specify columns from the same `colData()` with information on
+individual MS runs (and assays):
+
+```{r}
+#' Define columns for MS run and assays
 mscols <- msRunCols(location = "derived_spectra_data_file",
                     instrument_ref = "instrument", scan_polarity = "polarity")
 acols <- assayCols(assay = "derived_spectra_data_file")
-
-#' Add sample, MS run, assay and study variable information to the MTD
-mtd <- rbind(
-    mtd,
-    mtdFromSampleData(as.data.frame(colData(se)), sampleCols = scols,
-                      msRunCols = mscols, assayCols = acols,
-                      groups = c("age", "phenotype")))
-
-#' Create a MzTabM object
-mzt <- MzTabM(mtd = mtd)
 ```
 
-Need to add the *BTO* and the NCBI taxonomy ontology definition to the metadata.
+The column `"derived_spectra_data_file"` contains the MS data file name which we
+use both to define the MS runs and assays (assuming thus a 1:1 mapping between
+them).
+
+```{r}
+colData(se)$derived_spectra_data_file
+```
+
+At last we define also the study variables of the experiment. These can be
+technical characteristics or phenotype(s) of the samples. The present experiment
+consists of plasma samples of individuals with or without a cardiovascular
+disease (CVD) and repeated measurements of an external (serum) sample pools that
+was used as quality control sample. These are defined in `colData()` columns
+`"blood_sample_type"`, `"age"` and `"phenotype"`.
+
+```{r}
+#' technical variable: the sample matrix
+colData(se)$blood_sample_type
+#' phenotype of study samples or QC for QC samples
+colData(se)$phenotype
+#' age of study participants; NA for QC samples
+colData(se)$age
+```
+
+With these information defined we can use the `MzTabM()` function to create a
+template mzTab-M for the present experiment. Parameter `groups` defines the
+column names of the `SummarizedExperiment`'s `colData()` to be used as mzTab-M
+*study variable groups*.
+
+```{r}
+mzt <- MzTabM(se, id = "MTBLS8735", sampleCols = scols,
+              msRunCols = mscols, assayCols = acols,
+              groups = c("age", "phenotype", "blood_sample_type"))
+mzt
+```
+
+This `MzTabM` object contains only metadata information, but no
+abundances/feature data yet. Also, some general metadata are still missing and,
+if exported to a mzTab-M file, it might not yet validate. We are next adding the
+small molecule feature (SMF) content and, in the subsequent section *Completing
+the metadata content*, adding eventually missing required metadata fields.
+
+### Add feature abundance matrix (SMF)
+
+We next add feature abundance information to the mzTab-M. While the abundance
+values can be taken from one of the `assay()`s from the `SummarizedExperiment`,
+we need to provide also feature characteristics. These are usually available in
+the `SummarizedExperiment`s `rowData()`:
+
+```{r}
+rowData(se)
+```
+
+For our example we use column `"mzmed"` which defines the features' *m/z* value
+which can be mapped to the SMF field *exp_mass_to_charge* and `"rtmed"` that
+reports the median retention time of the feature which can be used for the SMF
+field *retention_time_in_seconds*. We will in addition add an optional field
+*feature_id* to report and add the IDs of the individual features from the
+`SummarizedExperiment`, which we add as a column `"feature_id"` to the
+`rowData()`:
+
+```{r}
+rowData(se)$feature_id <- rownames(se)
+```
+
+Similar to the metadata column mappings above, we define a mapping of SMF
+fields to `rowData()` columns using the `smfCols()` helper function:
+
+```{r}
+smf_cols <- smfCols(exp_mass_to_charge = "mzmed",
+                    retention_time_in_seconds = "rtmed",
+                    feature_id = "feature_id")
+```
+
+Providing these additional SMF mapping in the `MzTabM()` call above will compile
+a `MzTabM` object with an MTD and SMF section from the
+`SummarizedExperiment`. Parameter `assayName` defines which of the
+`SummarizedExperiment`'s assays will be used the SMF section.
+
+```{r}
+#' Create a MTD+SMF mzTab-M object from the SummarizedExperiment
+mzt <- MzTabM(se, id = "MTBLS8735", sampleCols = scols,
+              msRunCols = mscols, assayCols = acols,
+              groups = c("age", "phenotype", "blood_sample_type"),
+              smfCols. = smf_cols, assayName = "raw_filled")
+mzt
+```
+
+::: {.callout-note appearance = "minimal"}
+ℹ️ we could also use `smf(se, assayName = "raw_filled", smfCols. = smf_cols)` to
+extract the SMF table from the `SummarizedExperiment` and add that manually to
+the a `MzTabM` object.
+:::
+
+This `mzt` variable contains now the mzTab-M content that could be extracted
+from the `SummarizedExperiment`. The first rows of the metadata section are:
+
+```{r}
+mtd(mzt) |> head()
+```
+
+And the first lines of the SMF section:
+
+```{r}
+smf(mzt) |> head()
+```
+
+In the next section we will complete the data adding some metadata fields that
+could not be derived from the result object.
+
+### Completing the metadata content
+
+Some of the metadata information must be manually added, because it can not be
+extracted from the `SummarizedExperiment`. This depends also on the information
+compiled into the mzTab-M file. We used for example the *BTO* and *NCBITaxon*
+ontologies to describe the samples, but these two are not added by default. The
+`getMtdCv()` function can be used to get the set of defined
+controlled vocabularies (ontologies) in the `MzTabM` object:
+
+```{r}
+getMtdCv(mzt)
+```
+
+We therefore need to add the two missing vocabularies:
 
 ```{r}
 mzt <- setMtdCv(mzt, label = c("BTO", "NCBITaxon"),
@@ -176,27 +319,26 @@ mzt <- setMtdCv(mzt, label = c("BTO", "NCBITaxon"),
                         "https://www.ebi.ac.uk/ols4/ontologies/ncbitaxon"))
 ```
 
-Add instrument information:
-
-- chromatography instrument: Agilent 1290 Infinity UHPLC (MTBLS_000871)
-- column type: HILIC
-- column: ACQUITY UPLC BEH Amide (1.7 µm, 2.1 mm x 100 mm; Waters)
-- mass instrument: AB SCIEX TripleTOF 5600+ (MTBLS_000602)
-- ion source: electrospray ionization (MS_1000073)
-- mass analyzer: quadrupole time-of-flight (MTBLS_000699)
+Also, we add *xcms* as software to the `MzTabM`:
 
 ```{r}
-#' Adding MS instrument information; seems we can't add chromatography
-#' information (yet)? Also, adding an empty parameter for detector.
+mzt <- setMtdField(mzt, "software", "[MS, MS:1001582, xcms, 4.10.0]")
+getMtdField(mzt, "software")
+```
+
+Also, we need to add instrument information to the `MzTabM` object.
+
+```{r}
+#' Adding MS instrument information.
 mzt <- setMtdInstrument(
     mzt, name = "[MS, MS:1002584, AB Sciex TripleTOF 5600+, ]",
     source = "[MS, MS:1000073, ESI, ]",
     analyzer = c(`analyzer[1]` =
-                    "[MS, MS:1003763, quadrupole time-of-flight instrument, ]"),
+                     "[MS, MS:1003763, quadrupole time-of-flight instrument, ]"),
     detector = "[,,null,null]")
 ```
 
-Add contact information.
+And at last we add also contact information:
 
 ```{r}
 mzt <- setMtdContact(
@@ -207,50 +349,7 @@ mzt <- setMtdContact(
     orcid = c("0000-0002-6977-7147", "0009-0007-5429-6846"))
 ```
 
-Now the Metadata section of a mzTab-M is ready to be exported. Before doing that
- we add to the MzTabM object the SMF matrix.
-
-### Add feature abundance matrix (SMF)
-
-We next add the feature abundances to the mzTab-M. We need to specify which
-columns in the `SummarizedExperiment`'s `rowData()` contain information
-characterizing the individual features.
-
-```{r}
-colnames(rowData(se))
-```
-
-- *mzmed* defines the features *m/z* value and can be mapped to the SMF field
-  (column) *exp_mass_to_charge*.
-- *rtmed* reports the median retention time of the feature and can be used for
-  the SMF field *retention_time_in_seconds*. We will in addition add an optional
-  field *feature_id* to report and add the IDs of the individual features from
-  the `SummarizedExperiment`: add a column `"feature_id"` to the `rowData()`
-
-```{r}
-rowData(se)$feature_id <- rownames(se)
-```
-
-Define the mapping of SMF fields to `rowData()` columns:
-
-```{r}
-smf_cols <- smfCols(exp_mass_to_charge = "mzmed",
-    retention_time_in_seconds = "rtmed", feature_id = "feature_id")
-```
-
-We can use the `smf()` function to create the SMF section. For the SMF
-abundances we use the data from the `"raw_filled"` assay
-
-```{r}
-smf <- smf(se, assayName = "raw_filled", smfCols. = smf_cols)
-```
-
-Now we can creae a MzTabM object with MTD and SMF section. We extract the MTD
-section from the object we generate previously using the function `mtd()`.
-
-```{r}
-mztab <- MzTabM(mtd = mtd(mzt), smf = smf)
-```
+Now we have a complete mzTab-M content compiled and can proceed to export it.
 
 ### Export to an MTD+SMF mzTab-M file
 
@@ -262,8 +361,9 @@ absence of the SML section, which is expected given that we intentionally
 generated an MTD+SMF file.
 
 ```{r}
-writeMzTabM(mztab, path = file.path(tempdir(), "MTBLS8735_mtd_smf.mzTab"))
+writeMzTabM(mzt, path = file.path(tempdir(), "MTBLS8735_mtd_smf.mzTab"))
 ```
+
 
 ## Low-level functions
 

--- a/vignettes/rmztabm-api.qmd
+++ b/vignettes/rmztabm-api.qmd
@@ -854,3 +854,5 @@ General utility functions include:
 ```{r}
 sessionInfo()
 ```
+
+# References


### PR DESCRIPTION
Update the example in the vignette to export a `SummarizedExperiment` to mzTab-M: focus on the *RmzTabM* code and functionality assuming most of the information is already provided in the `SummarizedExperiment`. Also, use the `SummarizedExperiment` example data set available within the package.